### PR TITLE
REC-2965 Updated error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bunnyapp/api-client",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bunnyapp/api-client",
-      "version": "2.0.9",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -126,11 +126,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -627,12 +627,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -652,9 +646,9 @@
       }
     },
     "node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
     },
     "node_modules/locate-path": {
@@ -787,34 +781,34 @@
       }
     },
     "node_modules/nise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
+      "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
       }
     },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+    "node_modules/nise/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/normalize-path": {
@@ -884,13 +878,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunnyapp/api-client",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Node.js client for Bunny CRM",
   "main": "index.js",
   "directories": {

--- a/src/helpers/account-update-by-tenant-code.js
+++ b/src/helpers/account-update-by-tenant-code.js
@@ -49,10 +49,15 @@ module.exports = async function (tenantCode, attributes) {
   };
 
   const res = await this.query(query, variables);
+  const accountUpdate = res?.data?.accountUpdate;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
   }
 
-  return res?.data?.accountUpdate?.account;
+  if (accountUpdate?.errors) {
+    throw new Error(accountUpdate.errors.join());
+  }
+
+  return accountUpdate?.account;
 };

--- a/src/helpers/feature-usage-create.js
+++ b/src/helpers/feature-usage-create.js
@@ -46,10 +46,15 @@ module.exports = async function (
   }
 
   const res = await this.query(query, variables);
+  const featureUsageCreate = res?.data?.featureUsageCreate;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
   }
 
-  return res?.data?.featureUsageCreate?.featureUsage;
+  if (featureUsageCreate?.errors) {
+    throw new Error(featureUsageCreate.errors.join());
+  }
+
+  return featureUsageCreate?.featureUsage;
 };

--- a/src/helpers/portal-session-create.js
+++ b/src/helpers/portal-session-create.js
@@ -24,10 +24,15 @@ module.exports = async function (
   };
 
   const res = await this.query(query, variables);
+  const portalSessionCreate = res?.data?.portalSessionCreate;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
   }
 
-  return res?.data?.portalSessionCreate?.token;
+  if (portalSessionCreate?.errors) {
+    throw new Error(portalSessionCreate.errors.join());
+  }
+
+  return portalSessionCreate?.token;
 };

--- a/src/helpers/subscription-cancel.js
+++ b/src/helpers/subscription-cancel.js
@@ -15,9 +15,14 @@ module.exports = async function (subscriptionId) {
   };
 
   const res = await this.query(query, variables);
+  const subscriptionCancel = res?.data?.subscriptionCancel;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
+  }
+
+  if (subscriptionCancel?.errors) {
+    throw new Error(subscriptionCancel.errors.join());
   }
 
   return true;

--- a/src/helpers/subscription-create.js
+++ b/src/helpers/subscription-create.js
@@ -93,10 +93,15 @@ module.exports = async function (priceListCode, options = {}) {
   }
 
   const res = await this.query(query, variables);
+  const subscriptionCreate = res?.data?.subscriptionCreate;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
   }
 
-  return res?.data?.subscriptionCreate?.subscription;
+  if (subscriptionCreate?.errors) {
+    throw new Error(subscriptionCreate.errors.join());
+  }
+
+  return subscriptionCreate?.subscription;
 };

--- a/src/helpers/tenant-create.js
+++ b/src/helpers/tenant-create.js
@@ -41,10 +41,15 @@ module.exports = async function (
   };
 
   const res = await this.query(query, variables);
+  const tenantCreate = res?.data?.tenantCreate;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
   }
 
-  return res?.data?.tenantCreate?.tenant;
+  if (tenantCreate?.errors) {
+    throw new Error(tenantCreate.errors.join());
+  }
+
+  return tenantCreate?.tenant;
 };

--- a/src/helpers/tenant-metrics-update.js
+++ b/src/helpers/tenant-metrics-update.js
@@ -20,9 +20,14 @@ module.exports = async function (
   };
 
   const res = await this.query(query, variables);
+  const tenantMetricsUpdate = res?.data?.tenantMetricsUpdate;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
+  }
+
+  if (tenantMetricsUpdate?.errors) {
+    throw new Error(tenantMetricsUpdate.errors.join());
   }
 
   return true;

--- a/src/helpers/tenant-update.js
+++ b/src/helpers/tenant-update.js
@@ -24,10 +24,15 @@ module.exports = async function (id, code, name) {
   };
 
   const res = await this.query(query, variables);
+  const tenantUpdate = res?.data?.tenantUpdate;
 
   if (res?.errors) {
     throw new Error(res.errors.map((e) => e.message).join());
   }
 
-  return res?.data?.tenantUpdate?.tenant;
+  if (tenantUpdate?.errors) {
+    throw new Error(tenantUpdate.errors.join());
+  }
+
+  return tenantUpdate?.tenant;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,11 @@ class Bunny {
       }
 
       console.log("Authorization error: ", error);
+
+      if (error.response?.data?.error_description) {
+        return Promise.reject(error.response.data.error_description);
+      }
+
       return Promise.reject("Invalid access token");
     });
 


### PR DESCRIPTION
Some graphql requests to Bunny return errors in a different format which was not being picked up by the SDK. 

This update will throw errors if the different format of error is encountered instead of slinking quietly into the night. 

For example if a request to `portalSessionCreate` is made but the required scope is missing. Instead of just getting a null response you will now get an error indicating a required scope is missing. 